### PR TITLE
Get rid of the sleep for 2 seconds

### DIFF
--- a/lib/shenzhen/plugins/hockeyapp.rb
+++ b/lib/shenzhen/plugins/hockeyapp.rb
@@ -27,8 +27,6 @@ module Shenzhen::Plugins
 
         run_request_for_options(options)
 
-        sleep(2.seconds)
-
         options.delete(:ipa)
       end
 
@@ -40,8 +38,6 @@ module Shenzhen::Plugins
         options[:dsym] = Faraday::UploadIO.new(dsym_filename, 'application/octet-stream')
 
         run_request_for_options(options)
-
-        sleep(2.seconds)
 
         options.delete(:dsym)
       end


### PR DESCRIPTION
`2.seconds` will give `NoMethodError: undefined method`seconds' for 2:Fixnum`.
