### PR TITLE
Fix for file exists check

### DIFF
--- a/lib/shenzhen/plugins/itunesconnect.rb
+++ b/lib/shenzhen/plugins/itunesconnect.rb
@@ -42,11 +42,12 @@ module Shenzhen::Plugins
 
       def transport
         xcode = `xcode-select --print-path`.strip
-        tool = File.join(File.dirname(xcode), "Applications/Application Loader.app/Contents/MacOS/itms/bin/iTMSTransporter").gsub(/\s/, '\ ')
-        tool = File.join(File.dirname(xcode), "Applications/Application Loader.app/Contents/itms/bin/iTMSTransporter").gsub(/\s/, '\ ') if !File.exist?(tool)
+        tool = File.join(File.dirname(xcode), "Applications/Application Loader.app/Contents/MacOS/itms/bin/iTMSTransporter")
+        tool = File.join(File.dirname(xcode), "Applications/Application Loader.app/Contents/itms/bin/iTMSTransporter") if !File.exist?(tool)
+        tool = tool.gsub(/\s/, '\ ')
 
         escaped_password = Shellwords.escape(@password)
-        args = [tool, "-m upload", "-f Package.itmsp", "-u #{Shellwords.escape(@account)}", "-p #{escaped_password}"]
+        args = [tool, "-m upload", "-f Package.itmsp", "-u #{Shellwords.escape(@account)}", "-p #{escaped_password}", "--verbose"]
         command = args.join(' ')
 
         puts command.sub("-p #{escaped_password}", "-p ******") if $verbose


### PR DESCRIPTION
It seems like doing a file exists check with the space escaped, will cause the check to fail and mean the first file path is never tried. Escaping the spaces after the file exists check fixes the problem.

I also added the verbose option to the output from iTMSTransporter.
